### PR TITLE
Action rating_package_get is side_effect_free

### DIFF
--- a/ckanext/rating/logic/action.py
+++ b/ckanext/rating/logic/action.py
@@ -50,6 +50,8 @@ def rating_package_create(context, data_dict):
 
     return Rating.get_package_rating(package.id)
 
+
+@toolkit.side_effect_free
 def rating_package_get(context, data_dict):
     package_id = data_dict.get('package_id')
 


### PR DESCRIPTION
The get action doesn't cause a state change and so it is convenient and okay to call it via a GET request.